### PR TITLE
Feature: CLI command to set plugin settings

### DIFF
--- a/packages/tcore-cli/src/Commands/SetPluginSetting.ts
+++ b/packages/tcore-cli/src/Commands/SetPluginSetting.ts
@@ -1,0 +1,89 @@
+import path from "path";
+import fs from "fs";
+import { getMainSettings, getPluginSettings, Plugin, setPluginSettings } from "@tago-io/tcore-api";
+import chalk from "chalk";
+import { getSystemName } from "@tago-io/tcore-shared";
+import { log, oraLog } from "../Helpers/Log";
+
+/**
+ * Set a single setting for a plugin.
+ */
+export async function setPluginSetting(id: string, mod: string, key: string, value: string) {
+  const plugin = await getLocalPluginData(id);
+  if (!plugin) {
+    // we must have the plugin installed in order to know the actual ID
+    oraLog(`Plugin ${chalk.redBright(id)} is not installed`).fail();
+    return;
+  }
+  if (!key) {
+    // Key is already validated against undefined, but we need to know if
+    // the actual content is not empty, such as an empty string
+    oraLog(`Invalid setting ${chalk.redBright("key")}`).fail();
+    return;
+  }
+
+  oraLog(`Plugin ${chalk.green(plugin.name)} is installed`).succeed();
+
+  const settings = await getPluginSettings(plugin.id);
+  const modObject = settings.modules?.find((x) => x.id === mod);
+  if (modObject) {
+    // module already has some settings in the plugin file
+    modObject.values = { ...modObject.values, [key]: value };
+  } else {
+    // module doesn't have settings in the plugin file
+    settings.modules = [
+      ...(settings.modules || []),
+      {
+        id: mod,
+        disabled: false,
+        values: { [key]: value },
+      },
+    ];
+  }
+
+  await setPluginSettings(plugin.id, settings);
+
+  if (value === undefined || value === null) {
+    // empty value to remove the setting
+    log(`Setting ${chalk.green(key)} was removed from module ${chalk.green(mod)}`);
+  } else if (value === "") {
+    // value is an empty string
+    log(`Setting ${chalk.green(key)} was set to ${chalk.green(`""`)} for module ${chalk.green(mod)}`);
+  } else {
+    // value has something in it and was changed
+    log(`Setting ${chalk.green(key)} was set to ${chalk.green(value)} for module ${chalk.green(mod)}`);
+  }
+
+  log(`Restart ${getSystemName()} for the changes to take effect`);
+}
+
+/**
+ * Retrieves the information of a local plugin by its identifier.
+ * The identifier can be the `plugin ID` or the `plugin slug`.
+ */
+async function getLocalPluginData(identifier: string) {
+  const settings = await getMainSettings();
+  const plugins = await fs.promises.readdir(settings.plugin_folder);
+
+  for (const id of plugins) {
+    const pluginPath = path.join(settings.plugin_folder, id);
+    const pluginPkg = await Plugin.getPackageAsync(pluginPath).catch(() => null);
+
+    const pluginSlug = pluginPkg?.name;
+    const pluginID = Plugin.generatePluginID(pluginSlug);
+
+    if (pluginSlug === identifier || pluginID === identifier) {
+      const pluginSettings = await getPluginSettings(pluginID);
+      return {
+        folder: pluginPath,
+        id: pluginID,
+        name: pluginPkg.name,
+        pkg: pluginPkg,
+        slug: pluginSlug,
+        disabled: pluginSettings?.disabled || false,
+      };
+    }
+  }
+
+  return null;
+}

--- a/packages/tcore-cli/src/index.ts
+++ b/packages/tcore-cli/src/index.ts
@@ -9,8 +9,10 @@ import { status } from "./Commands/Status";
 import { stop } from "./Commands/Stop";
 import { restart } from "./Commands/Restart";
 import { addPluginCommands } from "./PluginCLI";
+import { setPluginSetting } from "./Commands/SetPluginSetting";
 
 /**
+ * Creates and returns the base program.
  */
 function getBaseProgram() {
   const program = new Command();
@@ -38,10 +40,20 @@ function getBaseProgram() {
 
   program.command("logs").description(`Shows the ${systemName} Server logs in real time`).action(showLogs);
 
+  program
+    .command("set-plugin-setting")
+    .description(`Set a setting for a specific plugin`)
+    .argument("<id>", "Plugin slug or ID")
+    .argument("<module>", "Plugin module")
+    .argument("<key>", "Setting key")
+    .argument("[value]", "Value for the setting key")
+    .action(setPluginSetting);
+
   return program;
 }
 
 /**
+ * Starts the cli, parses and executes the commands from argv.
  */
 async function startCLI() {
   await runVersionMigration().catch(() => null);


### PR DESCRIPTION
This PR adds a new CLI command to set a plugin's setting key. This is the syntax of the CLI command:

```bash
tagocore set-plugin-setting <id> <module> <key> [value]
```

- `id` can be the plugin slug or the plugin id
- `module` is the name of the module you want to set the setting in
- `key` is the name of the setting
- `value` is the actual value of the setting

The `value` argument is optional, and if it isn't informed the setting will be removed from the plugin settings.

It's only possible to set a setting for an installed plugin, because we need to know the actual ID of the plugin, and we can only know that if the plugin is installed.

Changing a plugin setting does not work in "realtime". You must restart the application for the plugin to use the new settings, or manually go to the plugin configuration page and save the changes.