### PR TITLE
Feature: Fallback to process.env for cli options on 'start' command

### DIFF
--- a/packages/tcore-cli/src/Commands/Start.ts
+++ b/packages/tcore-cli/src/Commands/Start.ts
@@ -31,8 +31,15 @@ function getEnv(opts: IStartOptions) {
     TCORE_SETTINGS_FOLDER: opts.settingsFolder,
   };
 
-  // removes undefined objects
-  Object.keys(env).forEach((key) => (!env[key] ? delete env[key] : {}));
+  // prioritizes the options passed in the CLI but if one of the values
+  // is falsy we try to use the process.env for that key
+  Object.keys(env).forEach((key) => {
+    env[key] ||= process.env[key];
+    if (!env[key]) {
+      // empty env
+      delete env[key];
+    }
+  });
 
   return env;
 }


### PR DESCRIPTION
This PR adds the functionality to fallback to process.env for `undefined` or `null` options in the cli `start` command.

For instance, if the `--port` option is not informed in the start command, the `process.env.TCORE_PORT` variable will be used.

If the option is still falsy at that point, it is removed from the env.