### PR TITLE
Fix: Negative numbers being requested from paginated table component

### DIFF
--- a/packages/tcore-console/src/Components/PaginatedTable/PaginatedTable.tsx
+++ b/packages/tcore-console/src/Components/PaginatedTable/PaginatedTable.tsx
@@ -209,6 +209,7 @@ function PaginatedTable<T>(props: IPaginatedTableProps<T>) {
   };
 
   /**
+   * Gets the ideal amount of rows to be rendered.
    */
   const getIdealAmountOfRows = () => {
     const node = rowsNode.current as HTMLDivElement;
@@ -216,7 +217,7 @@ function PaginatedTable<T>(props: IPaginatedTableProps<T>) {
       const headerHeight = 60;
       const tableHeight = node.getBoundingClientRect().height - headerHeight;
       const rowHeight = 35;
-      const idealAmount = Math.floor(tableHeight / rowHeight);
+      const idealAmount = Math.max(Math.floor(tableHeight / rowHeight), 0);
       return idealAmount;
     }
     return 0;

--- a/packages/tcore-sdk/src/Types/Common/Common.types.test.ts
+++ b/packages/tcore-sdk/src/Types/Common/Common.types.test.ts
@@ -175,6 +175,12 @@ describe("zQuery", () => {
     expect(() => zQuery.parse({ page: false })).toThrowError();
   });
 
+  test("doesn't allow negative amounts", () => {
+    const data: IQuery = { amount: -2 };
+    const parsed = zQuery.parse(data);
+    expect(parsed.amount).toEqual(0);
+  });
+
   test("parses amount correctly", () => {
     const data: IQuery = { amount: 10 };
     const parsed = zQuery.parse(data);

--- a/packages/tcore-sdk/src/Types/Common/Common.types.ts
+++ b/packages/tcore-sdk/src/Types/Common/Common.types.ts
@@ -52,7 +52,8 @@ export const zQuery = z.object({
   amount: z
     .preprocess(preprocessNumber, z.number())
     .nullish()
-    .transform((x) => x ?? 20),
+    .transform((x) => x ?? 20)
+    .transform((x) => Math.max(x, 0)),
   fields: z
     .array(z.string())
     .nullish()


### PR DESCRIPTION
The paginated table component requests records based on the total height of the component. When `window.innerHeight` < `component.height` the paginated component was requesting negative numbers in the `amount` field of the list query.

This PR fixes this situations, and improves the back-end to prevent negative numbers being request directly via the API as well.