### PR TITLE
Feature: Added deleteDeviceData and editDeviceData to core object

### DIFF
--- a/packages/tcore-api/src/Plugins/executePluginRequest.ts
+++ b/packages/tcore-api/src/Plugins/executePluginRequest.ts
@@ -51,6 +51,7 @@ async function executePluginRequest(pluginID: string, method: string, ...e: any[
     // deviceData
     case "getDeviceDataAmount"        : return call(pluginID, "device-data", DeviceDataService, "getDeviceDataAmount", ...e);
     case "addDeviceData"              : return call(pluginID, "device-data", DeviceDataService, "addDeviceData", ...e);
+    case "editDeviceData"             : return call(pluginID, "device-data", DeviceDataService, "editDeviceData", ...e);
     case "getDeviceData"              : return call(pluginID, "device-data", DeviceDataService, "getDeviceData", ...e);
     case "deleteDeviceData"           : return call(pluginID, "device-data", DeviceDataService, "deleteDeviceData", ...e);
 

--- a/packages/tcore-console/src/Components/Bucket/Common/VariablesTable/VariablesTable.style.ts
+++ b/packages/tcore-console/src/Components/Bucket/Common/VariablesTable/VariablesTable.style.ts
@@ -51,7 +51,7 @@ export const Pencil = styled.div`
 export const CopyButtonContainer = styled.div`
   position: absolute;
   left: 50%;
-  transform: translate(-50%, 0);
+  transform: translate(-50%, -50%);
 
   ${ButtonStyle.Container} {
     padding: 7px;

--- a/packages/tcore-console/src/Components/PaginatedTable/PaginatedTable.style.ts
+++ b/packages/tcore-console/src/Components/PaginatedTable/PaginatedTable.style.ts
@@ -48,7 +48,7 @@ const rowCSS = css<{ $highlightColor?: string }>`
     display: flex;
     align-items: center;
 
-    .inner-cell:not(.date) {
+    .inner-cell:not(.date):not(.icon) {
       overflow: hidden;
       text-overflow: ellipsis;
     }

--- a/packages/tcore-sdk/src/Lib/Core/Core.test.ts
+++ b/packages/tcore-sdk/src/Lib/Core/Core.test.ts
@@ -244,7 +244,7 @@ test("addDeviceData", async () => {
     variable: "temperature",
     value: 10,
   });
-  expect(response).toEqual(undefined);
+  expect(response).toEqual(true);
   expect(fn).toHaveBeenCalledWith("addDeviceData", "61261ef1f87480ff318b7bcb", {
     variable: "temperature",
     value: 10,

--- a/packages/tcore-sdk/src/Lib/Core/Core.ts
+++ b/packages/tcore-sdk/src/Lib/Core/Core.ts
@@ -29,6 +29,7 @@ import {
   TGenericToken,
   ILiveInspectorMessageCreate,
   TLiveInspectorConnectionID,
+  IDeviceDataEdit,
 } from "../../Types";
 import APIBridge from "../APIBridge/APIBridge";
 
@@ -248,8 +249,22 @@ class Core extends APIBridge {
   /**
    * Adds a data item into a device.
    */
-  public async addDeviceData(deviceID: TGenericID, data: any): Promise<void> {
-    await this.invokeApiMethod("addDeviceData", deviceID, data);
+  public async addDeviceData(deviceID: TGenericID, data: any): Promise<IDeviceData[]> {
+    return await this.invokeApiMethod("addDeviceData", deviceID, data);
+  }
+
+  /**
+   * Edits data from a device.
+   */
+  public async editDeviceData(deviceID: TGenericID, data: IDeviceDataEdit[]): Promise<IDeviceData[]> {
+    return await this.invokeApiMethod("editDeviceData", deviceID, data);
+  }
+
+  /**
+   * Delete data from a device.
+   */
+  public async deleteDeviceData(deviceID: TGenericID, ids: IDeviceDataQuery): Promise<void> {
+    await this.invokeApiMethod("deleteDeviceData", deviceID, ids);
   }
 
   /**

--- a/packages/tcore-sdk/src/Lib/HookModule/HookModule.ts
+++ b/packages/tcore-sdk/src/Lib/HookModule/HookModule.ts
@@ -16,6 +16,13 @@ class HookModule extends TCoreModule {
   public async onAfterInsertDeviceData(deviceID: TGenericID, data: IDeviceData[]): Promise<void> {
     throw new Error("Method not implemented");
   }
+
+  /**
+   * Called after the data sent by a device was edited in the bucket.
+   */
+  public async onAfterEditDeviceData(deviceID: TGenericID, data: IDeviceData[]): Promise<void> {
+    throw new Error("Method not implemented");
+  }
 }
 
 export default HookModule;

--- a/packages/tcore-sdk/src/Types/DatabaseModule/DatabaseModule.types.ts
+++ b/packages/tcore-sdk/src/Types/DatabaseModule/DatabaseModule.types.ts
@@ -17,7 +17,7 @@ import {
   zDeviceTokenCreate,
   zDeviceTokenListQuery,
   zPluginStorageItemSet,
-  zDeviceDataUpdate,
+  zDeviceDataEdit,
   zAccountTokenCreate,
   zAccountCreate,
   zAccountListQuery,
@@ -31,7 +31,7 @@ export type IDatabaseDeviceDataCreate = z.output<typeof zDeviceDataCreate>;
 /**
  * Data parameter of the `editDeviceData` function.
  */
-export type IDatabaseDeviceDataEdit = z.output<typeof zDeviceDataUpdate>;
+export type IDatabaseDeviceDataEdit = z.output<typeof zDeviceDataEdit>;
 
 /**
  * Data parameter of the `getDeviceData` functions.

--- a/packages/tcore-sdk/src/Types/DeviceData/DeviceData.types.ts
+++ b/packages/tcore-sdk/src/Types/DeviceData/DeviceData.types.ts
@@ -118,15 +118,21 @@ export const zDeviceDataCreate = zDeviceData
       created_at: now,
       id: generateResourceID(),
       time: data.time || now,
+      unit: data.unit || undefined,
     });
   });
 
 /**
- * Configuration to update a device data.
+ * Configuration to edit a single device data.
  */
-export const zDeviceDataUpdate = zDeviceData.omit({ created_at: true, variable: true, device: true }).extend({
-  location: zDeviceDataCreateLocation,
-  time: z.preprocess((x) => (x ? new Date(x as string) : undefined), z.date().nullish()),
+export const zDeviceDataEdit = z.object({
+  group: z.string().max(24).nullish(),
+  id: zObjectID,
+  location: zDeviceDataCreateLocation.optional(),
+  metadata: z.object({}).catchall(z.any()).or(z.array(z.any())).optional(),
+  time: z.preprocess((x) => (x ? new Date(x as string) : undefined), z.date()).optional(),
+  unit: z.string().optional(),
+  value: z.string().or(z.boolean()).or(z.number()).optional(),
 });
 
 /**
@@ -229,13 +235,14 @@ export const zDeviceDataQuery = z.preprocess(
 const zDeviceAddDataOptions = z.object({
   rawPayload: z.any().nullish(),
   liveInspectorID: z.string().nullish(),
+  returnDataSet: z.boolean().optional(),
 });
 
 export type IDeviceAddDataOptions = z.infer<typeof zDeviceAddDataOptions>;
 export type IDeviceData = z.infer<typeof zDeviceData>;
 export type IDeviceDataCreate = z.input<typeof zDeviceDataCreate>;
 export type IDeviceDataCreateLocation = z.input<typeof zDeviceDataCreateLocation>;
+export type IDeviceDataEdit = z.infer<typeof zDeviceDataEdit>;
 export type IDeviceDataLocationCoordinates = z.input<typeof zDeviceDataLocationCoordinates>;
 export type IDeviceDataLocationLatLng = z.input<typeof zDeviceDataLocationLatLng>;
 export type IDeviceDataQuery = z.input<typeof zDeviceDataQuery>;
-export type IDeviceDataUpdate = z.input<typeof zDeviceDataUpdate>;


### PR DESCRIPTION
This PR adds the `deleteDeviceData` and `editDeviceData` functions to the `core` object, which can be used by plugins. 