### PR TITLE
Fix: too many analysis logs

### DIFF
--- a/packages/tcore-api/src/Controllers/Analysis.ts
+++ b/packages/tcore-api/src/Controllers/Analysis.ts
@@ -9,7 +9,14 @@ import {
   zAnalysisEdit,
 } from "@tago-io/tcore-sdk/types";
 import { runAnalysis } from "../Services/AnalysisCodeExecution";
-import { createAnalysis, deleteAnalysis, editAnalysis, getAnalysisInfo, getAnalysisList } from "../Services/Analysis";
+import {
+  createAnalysis,
+  deleteAnalysis,
+  deleteAnalysisLogs,
+  editAnalysis,
+  getAnalysisInfo,
+  getAnalysisList,
+} from "../Services/Analysis";
 import APIController, { ISetupController, warm } from "./APIController";
 
 /**
@@ -64,6 +71,20 @@ class DeleteAnalysis extends APIController<void, void, z.infer<typeof zURLParams
 }
 
 /**
+ * Deletes all logs of an analysis.
+ */
+class DeleteAnalysisLogs extends APIController<void, void, z.infer<typeof zURLParamsID>> {
+  setup: ISetupController = {
+    allowTokens: [{ permission: "write", resource: "account" }],
+    zURLParamsParser: zURLParamsID,
+  };
+
+  public async main() {
+    await deleteAnalysisLogs(this.urlParams.id);
+  }
+}
+
+/**
  * Runs a single analysis.
  */
 class RunAnalysis extends APIController<any, void, z.infer<typeof zURLParamsID>> {
@@ -112,6 +133,7 @@ class CreateAnalysis extends APIController<IAnalysisCreate, void, void> {
  * Exports the routes of the analysis.
  */
 export default (app: Application) => {
+  app.delete("/analysis/:id/log", warm(DeleteAnalysisLogs));
   app.delete("/analysis/:id", warm(DeleteAnalysis));
   app.get("/analysis/:id/run", warm(RunAnalysis));
   app.post("/analysis/:id/run", warm(RunAnalysis));

--- a/packages/tcore-api/src/Services/Analysis.ts
+++ b/packages/tcore-api/src/Services/Analysis.ts
@@ -88,6 +88,14 @@ export async function deleteAnalysis(id: TGenericID): Promise<void> {
 }
 
 /**
+ * Deletes all logs of an analysis.
+ */
+export async function deleteAnalysisLogs(id: TGenericID): Promise<void> {
+  await validateAnalysisID(id);
+  await invokeDatabaseFunction("deleteAnalysisLogs", id);
+}
+
+/**
  * Creates a new analysis.
  */
 export async function createAnalysis(analysis: IAnalysisCreate): Promise<TGenericID> {

--- a/packages/tcore-console/src/Components/Analysis/Common/ConsoleOptions/ConsoleOptions.style.ts
+++ b/packages/tcore-console/src/Components/Analysis/Common/ConsoleOptions/ConsoleOptions.style.ts
@@ -1,0 +1,50 @@
+import styled, { css } from "styled-components";
+
+export const Container = styled.div<{ visible: boolean }>`
+  position: absolute;
+  right: 10px;
+  top: 45px;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  padding: 5px 0px;
+  background: white;
+  border-radius: 5px;
+  box-shadow: 0px 2px 8px 0px rgba(0, 0, 0, 0.2);
+  opacity: 0;
+  margin-top: -10px;
+  transition: opacity 0.2s, margin 0.3s;
+  transition-timing-function: cubic-bezier(0.17, 0.67, 0.2, 1.37);
+
+  .item {
+    padding: 7px 13px;
+    display: flex;
+    cursor: pointer;
+    align-items: center;
+
+    span {
+      margin-left: 5px;
+    }
+
+    &:hover {
+      background: ${(props) => props.theme.buttonPrimary};
+
+      * {
+        color: ${(props) => props.theme.buttonPrimaryFont};
+        fill: ${(props) => props.theme.buttonPrimaryFont};
+      }
+    }
+  }
+
+  ${(props) =>
+    props.visible &&
+    css`
+      opacity: 1;
+      margin-top: 0px;
+      pointer-events: inherit;
+    `}
+
+  ${(props) =>
+    !props.visible &&
+    css`
+      pointer-events: none;
+    `}
+`;

--- a/packages/tcore-console/src/Components/Analysis/Common/ConsoleOptions/ConsoleOptions.tsx
+++ b/packages/tcore-console/src/Components/Analysis/Common/ConsoleOptions/ConsoleOptions.tsx
@@ -1,0 +1,37 @@
+import { memo, useEffect } from "react";
+import Icon from "../../../Icon/Icon";
+import { EIcon } from "../../../Icon/Icon.types";
+import * as Style from "./ConsoleOptions.style";
+
+/**
+ * Props.
+ */
+interface IConsoleOptionsProps {
+  visible: boolean;
+  onDelete: () => void;
+  onClose: () => void;
+}
+
+function ConsoleOptions(props: IConsoleOptionsProps) {
+  const { onDelete, onClose, visible } = props;
+
+  useEffect(() => {
+    function onMouseDown() {
+      onClose();
+    }
+
+    window.addEventListener("click", onMouseDown);
+    return () => window.removeEventListener("click", onMouseDown);
+  }, [onClose]);
+
+  return (
+    <Style.Container visible={visible}>
+      <div className="item" onClick={onDelete}>
+        <Icon size="12px" icon={EIcon["trash-alt"]} />
+        <span>Delete logs permanently</span>
+      </div>
+    </Style.Container>
+  );
+}
+
+export default memo(ConsoleOptions);

--- a/packages/tcore-console/src/Components/Analysis/Edit/AnalysisEdit.tsx
+++ b/packages/tcore-console/src/Components/Analysis/Edit/AnalysisEdit.tsx
@@ -15,6 +15,7 @@ import editAnalysis from "../../../Requests/editAnalysis";
 import runAnalysis from "../../../Requests/runAnalysis";
 import store from "../../../System/Store";
 import { getSocket } from "../../../System/Socket";
+import deleteAnalysisLogs from "../../../Requests/deleteAnalysisLogs";
 import AnalysisTab from "./AnalysisTab/AnalysisTab";
 import EnvVarsTab from "./EnvVarsTab/EnvVarsTab";
 import MoreTab from "./MoreTab/MoreTab";
@@ -137,6 +138,14 @@ function AnalysisEdit() {
   }, []);
 
   /**
+   * Deletes the logs.
+   */
+  const deleteLogs = useCallback(() => {
+    deleteAnalysisLogs(id);
+    clearLogs();
+  }, [clearLogs, id]);
+
+  /**
    * Called when a field from a tab gets modified.
    * This will apply the change to the data state.
    */
@@ -151,7 +160,15 @@ function AnalysisEdit() {
    * Renders the `Analysis` tab.
    */
   const renderAnalysisTab = () => {
-    return <AnalysisTab onClearLogs={clearLogs} logs={logs} data={data} onChange={onChangeData} />;
+    return (
+      <AnalysisTab
+        onClearLogs={clearLogs}
+        onDeleteLogs={deleteLogs}
+        logs={logs}
+        data={data}
+        onChange={onChangeData}
+      />
+    );
   };
 
   /**

--- a/packages/tcore-console/src/Components/Analysis/Edit/AnalysisTab/AnalysisTab.style.ts
+++ b/packages/tcore-console/src/Components/Analysis/Edit/AnalysisTab/AnalysisTab.style.ts
@@ -39,7 +39,19 @@ export const ConsoleHeader = styled.div`
     font-weight: 500;
   }
 
+  button {
+    border: 1px solid rgba(0, 0, 0, 0.1);
+  }
+
   button:first-child {
     margin-right: 5px;
+  }
+
+  .ban-append {
+    margin-left: -1px;
+    border-bottom-left-radius: 0;
+    border-top-left-radius: 0;
+    padding: 0px 5px;
+    height: 33px;
   }
 `;

--- a/packages/tcore-console/src/Components/Console/Console.tsx
+++ b/packages/tcore-console/src/Components/Console/Console.tsx
@@ -42,11 +42,11 @@ function Console(props: IConsoleProps) {
   /**
    * Renders a single line.
    */
-  const renderLog = (item: any) => {
+  const renderLog = (item: any, index: number) => {
     const format = showDate ? "yyyy-LL-dd HH:mm:ss.SSS" : "HH:mm:ss.SSS";
     const date = getDateTimeObject(item.timestamp)?.toFormat(format);
     return (
-      <Style.Row error={item.error} key={item.timestamp + item.message}>
+      <Style.Row error={item.error} key={item.timestamp + item.message + index}>
         <b className="date">[{date}]: </b>
         <span>{item.message}</span>
       </Style.Row>

--- a/packages/tcore-console/src/Requests/deleteAnalysisLogs.ts
+++ b/packages/tcore-console/src/Requests/deleteAnalysisLogs.ts
@@ -1,0 +1,13 @@
+import { TGenericID } from "@tago-io/tcore-sdk/types";
+import axios from "axios";
+import store from "../System/Store";
+
+/**
+ * Deletes all logs of an analysis.
+ */
+async function deleteAnalysisLogs(id: TGenericID): Promise<void> {
+  const headers = { token: store.token, masterPassword: store.masterPassword };
+  await axios.delete(`/analysis/${id}/log`, { headers });
+}
+
+export default deleteAnalysisLogs;

--- a/packages/tcore-sdk/src/Lib/DatabaseModule/DatabaseModule.ts
+++ b/packages/tcore-sdk/src/Lib/DatabaseModule/DatabaseModule.ts
@@ -417,6 +417,13 @@ class DatabaseModule extends TCoreModule {
   }
 
   /**
+   * Deletes all logs of an analysis.
+   */
+  public async deleteAnalysisLogs(analysisID: TGenericID): Promise<void> {
+    throw new Error("Method not implemented");
+  }
+
+  /**
    * Creates a new analysis.
    */
   public async createAnalysis(data: IDatabaseCreateAnalysisData): Promise<void> {


### PR DESCRIPTION
This PR prevents too many analysis logs from being fetched from the database, and it also adds the possibility for the developer to erase all logs of an analysis via a new route `DELETE /analysis/:id/log`