### PR TITLE
TCORE-302 file_path should be optional for standalone executables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ newrelic_agent.log
 *.tcore
 __build__*
 build*/
+
+# Temporary test files
+temp/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tago-io/tagocore",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": "TagoIO Inc.",
   "description": "TagoCore by TagoIO",
   "license": "Apache-2.0",

--- a/packages/server/Services/AnalysisCodeExecution.ts
+++ b/packages/server/Services/AnalysisCodeExecution.ts
@@ -32,11 +32,6 @@ export async function runAnalysis(id: string, data: any): Promise<void> {
   const settings = await getMainSettings();
 
   try {
-    const filePath = await invokeFilesystemFunction(
-      "resolveFile",
-      analysis.file_path,
-    );
-
     if (!analysis.active) {
       const message = `The analysis is deactivated and can't run. To run the analysis activate it.`;
       throw new Error(message);
@@ -45,16 +40,26 @@ export async function runAnalysis(id: string, data: any): Promise<void> {
       const message = "Binary executable path is missing";
       throw new Error(message);
     }
-    if (!analysis.file_path || !fs.existsSync(filePath)) {
-      const message = `File path is missing or doesn't exist`;
-      throw new Error(message);
+
+    let filePath: string | null = null;
+    if (analysis.file_path) {
+      const resolvedPath = await invokeFilesystemFunction(
+        "resolveFile",
+        analysis.file_path,
+      );
+      if (!fs.existsSync(resolvedPath)) {
+        const message = `File path doesn't exist: ${resolvedPath}`;
+        throw new Error(message);
+      }
+      filePath = resolvedPath;
     }
 
     addLog(false, id, `Starting analysis ${id}`);
 
     const localAddress = `http://localhost:${settings.port}`;
 
-    const child = spawn(`${analysis.binary_path}`, [filePath], {
+    const args = filePath ? [filePath] : [];
+    const child = spawn(`${analysis.binary_path}`, args, {
       env: {
         T_ANALYSIS_CONTEXT: "tago-io",
         T_ANALYSIS_ENV: stringifySafe(analysis.variables || []),

--- a/plugins/tagoio-integration/src/back/RealtimeConnection.ts
+++ b/plugins/tagoio-integration/src/back/RealtimeConnection.ts
@@ -114,7 +114,7 @@ async function emitStartData(token: string, connID: string) {
     os: osInfo,
     system_start_time: systemStartTime,
     tcore_start_time: tcoreStartTime,
-    tcore_version: "1.0.2",
+    tcore_version: "1.0.3",
     summary: data[0],
     computer_usage: computerUsage,
     last_ping: Date.now(),


### PR DESCRIPTION
## Problem
Analysis execution was incorrectly requiring `file_path` for all scenarios, including standalone compiled executables. This contradicted the official TagoCore documentation which states that `file_path` can be left empty for standalone executables.

## Investigation
- Documentation confirms `file_path` is optional for standalone binaries
- Schema definitions mark both `binary_path` and `file_path` as nullable
- Current code enforced `file_path` validation for all cases
- Two distinct use cases exist:
  - **Interpreted scripts**: `binary_path` = interpreter (python3/node), `file_path` = script file
  - **Standalone executables**: `binary_path` = compiled binary, `file_path` = not needed

## Solution
Updated validation logic in `AnalysisCodeExecution.ts`:
- Made `file_path` validation conditional - only validates when provided
- Updated spawn arguments to pass empty array for standalone binaries
- Binaries execute directly without file arguments
- Interpreted scripts continue to receive file path as expected

Tested with both standalone binary and Python script to verify both scenarios work correctly.